### PR TITLE
add map mode in searching

### DIFF
--- a/components/search/MapView.tsx
+++ b/components/search/MapView.tsx
@@ -1,0 +1,161 @@
+// components/search/MapView.tsx - 修正版
+import React, { useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+
+// Leaflet関連のインポートを動的インポートの中で行う
+const DynamicMap = dynamic(
+  () => import('./MapViewInner'), 
+  {
+    ssr: false,
+    loading: () => (
+      <div className="map-loading" style={{
+        height: '600px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#f9fafb',
+        borderRadius: '0.75rem',
+        border: '1px solid #e5e7eb',
+        color: '#6b7280'
+      }}>
+        <div className="loading-spinner" style={{
+          fontSize: '2rem',
+          marginBottom: '1rem',
+          animation: 'spin 2s linear infinite'
+        }}>
+          🗺️
+        </div>
+        <p style={{ fontSize: '0.875rem' }}>地図を読み込み中...</p>
+        <style jsx>{`
+          @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+          }
+        `}</style>
+      </div>
+    )
+  }
+);
+
+// 型定義
+interface Service {
+  id: number;
+  availability: 'available' | 'unavailable';
+  capacity: number | null;
+  current_users: number;
+  service?: {
+    name: string;
+    category: string;
+    description: string;
+  };
+}
+
+interface Facility {
+  id: number;
+  name: string;
+  description: string | null;
+  appeal_points: string | null;
+  address: string;
+  district: string;
+  latitude: number | null;
+  longitude: number | null;
+  phone_number: string | null;
+  website_url: string | null;
+  image_url: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  services?: Service[];
+}
+
+// メインMapViewコンポーネント
+const MapView: React.FC<{ 
+  facilities: Facility[];
+  loading?: boolean;
+}> = ({ facilities, loading = false }) => {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  // 座標を持つ施設のみをフィルタリング
+  const validFacilities = useMemo(() => 
+    facilities.filter(f => f.latitude && f.longitude && 
+                        !isNaN(f.latitude) && !isNaN(f.longitude)),
+    [facilities]
+  );
+
+  console.log('MapView レンダリング:', { 
+    facilities: facilities.length, 
+    validFacilities: validFacilities.length, 
+    loading,
+    isClient
+  });
+
+  // クライアントサイドでない場合はローディングを表示
+  if (!isClient) {
+    return (
+      <div className="map-loading" style={{
+        height: '600px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#f9fafb',
+        borderRadius: '0.75rem',
+        border: '1px solid #e5e7eb',
+        color: '#6b7280'
+      }}>
+        <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>🗺️</div>
+        <p>地図を準備中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="map-container" style={{ width: '100%', marginTop: '1rem' }}>
+      {/* 検索結果がない場合の表示 */}
+      {validFacilities.length === 0 && !loading && (
+        <div className="map-no-results" style={{
+          textAlign: 'center',
+          padding: '3rem',
+          backgroundColor: '#f9fafb',
+          borderRadius: '0.75rem',
+          border: '1px solid #e5e7eb',
+          marginBottom: '1rem'
+        }}>
+          <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>🗺️</div>
+          <h3 style={{ margin: '0 0 0.5rem 0', color: '#374151' }}>
+            地図に表示できる事業所がありません
+          </h3>
+          <p style={{ color: '#6b7280', fontSize: '0.875rem', margin: 0 }}>
+            位置情報が登録されている事業所を検索してください
+          </p>
+        </div>
+      )}
+      
+      {/* 動的に読み込まれる地図コンポーネント */}
+      <DynamicMap facilities={validFacilities} loading={loading} />
+      
+      {/* 統計情報 */}
+      {validFacilities.length > 0 && !loading && (
+        <div className="map-stats" style={{
+          textAlign: 'center',
+          marginTop: '1rem',
+          padding: '0.75rem',
+          backgroundColor: '#f0fdf4',
+          borderRadius: '0.5rem',
+          color: '#166534',
+          fontSize: '0.875rem',
+          fontWeight: '500'
+        }}>
+          <span>📍 {validFacilities.length}件の事業所を地図上に表示</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MapView;

--- a/components/search/MapViewInner.tsx
+++ b/components/search/MapViewInner.tsx
@@ -1,0 +1,431 @@
+// components/search/MapViewInner.tsx - 実際の地図コンポーネント
+import React, { useEffect, useMemo, useState } from 'react';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import { LatLngBounds } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+// Leafletのデフォルトマーカーアイコンの問題を修正
+import L from 'leaflet';
+
+// 型定義
+interface Service {
+  id: number;
+  availability: 'available' | 'unavailable';
+  capacity: number | null;
+  current_users: number;
+  service?: {
+    name: string;
+    category: string;
+    description: string;
+  };
+}
+
+interface Facility {
+  id: number;
+  name: string;
+  description: string | null;
+  appeal_points: string | null;
+  address: string;
+  district: string;
+  latitude: number | null;
+  longitude: number | null;
+  phone_number: string | null;
+  website_url: string | null;
+  image_url: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  services?: Service[];
+}
+
+// アイコン設定の修正
+const createFacilityIcon = () => {
+  // デフォルトアイコンの問題を修正
+  delete (L.Icon.Default.prototype as any)._getIconUrl;
+  L.Icon.Default.mergeOptions({
+    iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+    iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+  });
+
+  // カスタムアイコン
+  return new L.Icon({
+    iconUrl: 'data:image/svg+xml;base64,' + btoa(`
+      <svg width="25" height="35" viewBox="0 0 25 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12.5 0C5.6 0 0 5.6 0 12.5C0 19.4 12.5 35 12.5 35C12.5 35 25 19.4 25 12.5C25 5.6 19.4 0 12.5 0Z" fill="#22c55e"/>
+        <circle cx="12.5" cy="12.5" r="7" fill="white"/>
+        <circle cx="12.5" cy="12.5" r="4" fill="#22c55e"/>
+      </svg>
+    `),
+    shadowUrl: 'data:image/svg+xml;base64,' + btoa(`
+      <svg width="25" height="15" viewBox="0 0 25 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <ellipse cx="12.5" cy="7.5" rx="12" ry="7" fill="rgba(0,0,0,0.2)"/>
+      </svg>
+    `),
+    iconSize: [25, 35],
+    iconAnchor: [12, 35],
+    popupAnchor: [1, -34],
+    shadowSize: [25, 15],
+    shadowAnchor: [12, 15]
+  });
+};
+
+// 地図の境界を自動調整するコンポーネント
+const MapBounds: React.FC<{ facilities: Facility[] }> = ({ facilities }) => {
+  const map = useMap();
+
+  useEffect(() => {
+    if (facilities.length > 0) {
+      try {
+        const bounds = new LatLngBounds(
+          facilities.map(f => [f.latitude!, f.longitude!])
+        );
+        
+        // 施設が1つの場合は特定のズームレベルを設定
+        if (facilities.length === 1) {
+          map.setView([facilities[0].latitude!, facilities[0].longitude!], 15);
+        } else {
+          map.fitBounds(bounds, { 
+            padding: [20, 20],
+            maxZoom: 16
+          });
+        }
+      } catch (error) {
+        console.error('地図の境界設定でエラー:', error);
+        // デフォルトは東京都庁の位置
+        map.setView([35.6762, 139.6503], 11);
+      }
+    } else {
+      // デフォルトは東京都庁の位置
+      map.setView([35.6762, 139.6503], 11);
+    }
+  }, [facilities, map]);
+
+  return null;
+};
+
+// 事業所ポップアップの内容
+const FacilityPopup: React.FC<{ facility: Facility }> = ({ facility }) => {
+  const availableServices = facility.services?.filter(s => s.availability === 'available') || [];
+  const unavailableServices = facility.services?.filter(s => s.availability === 'unavailable') || [];
+
+  return (
+    <div style={{ maxWidth: '280px', fontSize: '0.875rem' }}>
+      <h3 style={{ 
+        fontSize: '1rem', 
+        fontWeight: 'bold', 
+        color: '#111827',
+        marginBottom: '0.5rem',
+        lineHeight: 1.3
+      }}>
+        {facility.name}
+      </h3>
+      
+      <p style={{ 
+        color: '#6b7280', 
+        fontSize: '0.75rem',
+        marginBottom: '0.75rem'
+      }}>
+        📍 {facility.district}
+      </p>
+      
+      {facility.description && (
+        <p style={{ 
+          color: '#374151',
+          fontSize: '0.75rem',
+          lineHeight: 1.4,
+          marginBottom: '0.75rem'
+        }}>
+          {facility.description.length > 80 
+            ? facility.description.slice(0, 80) + '...' 
+            : facility.description}
+        </p>
+      )}
+
+      {facility.appeal_points && (
+        <div style={{ marginBottom: '0.75rem' }}>
+          <div style={{ 
+            fontSize: '0.75rem', 
+            fontWeight: '500', 
+            color: '#374151',
+            marginBottom: '0.25rem'
+          }}>
+            ✨ アピールポイント
+          </div>
+          <p style={{ 
+            fontSize: '0.75rem', 
+            color: '#22c55e', 
+            fontWeight: '500',
+            lineHeight: 1.3
+          }}>
+            {facility.appeal_points.length > 60 
+              ? facility.appeal_points.slice(0, 60) + '...' 
+              : facility.appeal_points}
+          </p>
+        </div>
+      )}
+
+      <div style={{ marginBottom: '0.75rem' }}>
+        <div style={{ 
+          fontSize: '0.75rem', 
+          fontWeight: '500', 
+          color: '#374151',
+          marginBottom: '0.5rem'
+        }}>
+          提供サービス
+        </div>
+        <div style={{ 
+          display: 'flex', 
+          flexWrap: 'wrap', 
+          gap: '0.25rem'
+        }}>
+          {availableServices.slice(0, 3).map((service, index) => (
+            <span
+              key={index}
+              style={{
+                padding: '0.125rem 0.375rem',
+                borderRadius: '0.25rem',
+                fontSize: '0.625rem',
+                fontWeight: '500',
+                background: '#dcfce7',
+                color: '#166534'
+              }}
+            >
+              ○ {service.service?.name || 'サービス'}
+            </span>
+          ))}
+          {unavailableServices.slice(0, 2).map((service, index) => (
+            <span
+              key={`unavailable-${index}`}
+              style={{
+                padding: '0.125rem 0.375rem',
+                borderRadius: '0.25rem',
+                fontSize: '0.625rem',
+                fontWeight: '500',
+                background: '#f3f4f6',
+                color: '#6b7280'
+              }}
+            >
+              × {service.service?.name || 'サービス'}
+            </span>
+          ))}
+          {(availableServices.length + unavailableServices.length) > 5 && (
+            <span style={{
+              padding: '0.125rem 0.375rem',
+              borderRadius: '0.25rem',
+              fontSize: '0.625rem',
+              background: '#e5e7eb',
+              color: '#6b7280'
+            }}>
+              他{(availableServices.length + unavailableServices.length) - 5}件
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div style={{ marginBottom: '0.75rem' }}>
+        {facility.phone_number && (
+          <p style={{ fontSize: '0.75rem', color: '#6b7280', marginBottom: '0.125rem' }}>
+            📞 {facility.phone_number}
+          </p>
+        )}
+        {facility.website_url && (
+          <p style={{ fontSize: '0.75rem', marginBottom: '0.125rem' }}>
+            🌐 <a 
+              href={facility.website_url} 
+              target="_blank" 
+              rel="noopener noreferrer"
+              style={{ color: '#2563eb', textDecoration: 'none' }}
+              onMouseOver={(e) => (e.target as HTMLElement).style.textDecoration = 'underline'}
+              onMouseOut={(e) => (e.target as HTMLElement).style.textDecoration = 'none'}
+            >
+              ウェブサイト
+            </a>
+          </p>
+        )}
+      </div>
+
+      <div style={{ textAlign: 'center' }}>
+        <button
+          style={{
+            background: '#22c55e',
+            color: 'white',
+            padding: '0.375rem 1rem',
+            border: 'none',
+            borderRadius: '0.375rem',
+            fontSize: '0.75rem',
+            fontWeight: '500',
+            cursor: 'pointer',
+            transition: 'background-color 0.2s'
+          }}
+          onMouseOver={(e) => (e.target as HTMLElement).style.background = '#16a34a'}
+          onMouseOut={(e) => (e.target as HTMLElement).style.background = '#22c55e'}
+          onClick={() => {
+            console.log('詳細ページへ:', facility.id);
+          }}
+        >
+          詳細を見る
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// 実際の地図コンポーネント
+const MapViewInner: React.FC<{ 
+  facilities: Facility[];
+  loading?: boolean;
+}> = ({ facilities, loading = false }) => {
+  const [facilityIcon, setFacilityIcon] = useState<L.Icon | null>(null);
+  const [mapError, setMapError] = useState<string | null>(null);
+
+  // アイコンの初期化
+  useEffect(() => {
+    try {
+      const icon = createFacilityIcon();
+      setFacilityIcon(icon);
+    } catch (error) {
+      console.error('アイコン作成エラー:', error);
+      setMapError('地図アイコンの読み込みに失敗しました');
+    }
+  }, []);
+
+  // 東京都の中心座標（デフォルト表示位置）
+  const tokyoCenter: [number, number] = [35.6762, 139.6503];
+
+  console.log('MapViewInner レンダリング:', { 
+    facilities: facilities.length,
+    loading,
+    facilityIcon: !!facilityIcon
+  });
+
+  // エラー状態の表示
+  if (mapError) {
+    return (
+      <div style={{
+        height: '600px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#fef2f2',
+        borderRadius: '0.75rem',
+        border: '1px solid #fecaca',
+        color: '#dc2626'
+      }}>
+        <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>❌</div>
+        <p>{mapError}</p>
+        <button 
+          onClick={() => {
+            setMapError(null);
+            window.location.reload();
+          }}
+          style={{
+            marginTop: '1rem',
+            padding: '0.5rem 1rem',
+            background: '#dc2626',
+            color: 'white',
+            border: 'none',
+            borderRadius: '0.375rem',
+            cursor: 'pointer'
+          }}
+        >
+          再読み込み
+        </button>
+      </div>
+    );
+  }
+
+  // アイコンがまだ読み込まれていない場合
+  if (!facilityIcon) {
+    return (
+      <div style={{
+        height: '600px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#f9fafb',
+        borderRadius: '0.75rem',
+        border: '1px solid #e5e7eb',
+        color: '#6b7280'
+      }}>
+        <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>⏳</div>
+        <p>地図を準備中...</p>
+      </div>
+    );
+  }
+
+  try {
+    return (
+      <MapContainer
+        center={tokyoCenter}
+        zoom={11}
+        style={{ 
+          height: '600px', 
+          width: '100%', 
+          borderRadius: '0.75rem',
+          border: '1px solid #e5e7eb'
+        }}
+        scrollWheelZoom={true}
+        zoomControl={true}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          maxZoom={19}
+        />
+        
+        {/* 地図の境界を自動調整 */}
+        <MapBounds facilities={facilities} />
+        
+        {/* 施設マーカー */}
+        {facilities.map((facility) => (
+          <Marker
+            key={facility.id}
+            position={[facility.latitude!, facility.longitude!]}
+            icon={facilityIcon}
+          >
+            <Popup maxWidth={300} closeButton={true}>
+              <FacilityPopup facility={facility} />
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    );
+  } catch (error) {
+    console.error('地図レンダリングエラー:', error);
+    return (
+      <div style={{
+        height: '600px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#fef2f2',
+        borderRadius: '0.75rem',
+        border: '1px solid #fecaca',
+        color: '#dc2626'
+      }}>
+        <div style={{ fontSize: '2rem', marginBottom: '1rem' }}>❌</div>
+        <p>地図の読み込みに失敗しました</p>
+        <button 
+          onClick={() => window.location.reload()}
+          style={{
+            marginTop: '1rem',
+            padding: '0.5rem 1rem',
+            background: '#dc2626',
+            color: 'white',
+            border: 'none',
+            borderRadius: '0.375rem',
+            cursor: 'pointer'
+          }}
+        >
+          再読み込み
+        </button>
+      </div>
+    );
+  }
+};
+
+export default MapViewInner;

--- a/components/ui/ToggleSwitch.tsx
+++ b/components/ui/ToggleSwitch.tsx
@@ -1,0 +1,55 @@
+// components/ui/ToggleSwitch.tsx
+import React from 'react';
+
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  leftLabel: string;
+  rightLabel: string;
+  leftIcon?: string;
+  rightIcon?: string;
+  disabled?: boolean;
+}
+
+const ToggleSwitch: React.FC<ToggleSwitchProps> = ({
+  checked,
+  onChange,
+  leftLabel,
+  rightLabel,
+  leftIcon,
+  rightIcon,
+  disabled = false
+}) => {
+  return (
+    <div className="toggle-switch-container">
+      <div className="toggle-switch-wrapper">
+        <label 
+          className={`toggle-switch-label ${!checked ? 'active' : ''}`}
+          onClick={() => !disabled && onChange(false)}
+        >
+          {leftIcon && <span className="toggle-icon">{leftIcon}</span>}
+          {leftLabel}
+        </label>
+        
+        <div 
+          className={`toggle-switch ${checked ? 'checked' : ''} ${disabled ? 'disabled' : ''}`}
+          onClick={() => !disabled && onChange(!checked)}
+        >
+          <div className="toggle-switch-slider">
+            <div className="toggle-switch-thumb" />
+          </div>
+        </div>
+        
+        <label 
+          className={`toggle-switch-label ${checked ? 'active' : ''}`}
+          onClick={() => !disabled && onChange(true)}
+        >
+          {rightIcon && <span className="toggle-icon">{rightIcon}</span>}
+          {rightLabel}
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default ToggleSwitch;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
+import "leaflet/dist/leaflet.css";
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -784,3 +784,274 @@ a {
 .pagination-container.loading .pagination-number {
   opacity: 0.5;
 }
+
+/* トグルスイッチのスタイル */
+.toggle-switch-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: white;
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border: 1px solid #e5e7eb;
+}
+
+.toggle-switch-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem;
+  background: #f9fafb;
+  border-radius: 0.75rem;
+  border: 1px solid #e5e7eb;
+}
+
+.toggle-switch-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  border-radius: 0.5rem;
+  transition: all 0.2s;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.toggle-switch-label:hover {
+  color: #374151;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.toggle-switch-label.active {
+  color: #22c55e;
+  background: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  font-weight: 600;
+}
+
+.toggle-icon {
+  font-size: 1rem;
+}
+
+.toggle-switch {
+  position: relative;
+  width: 3.5rem;
+  height: 1.75rem;
+  background: #e5e7eb;
+  border-radius: 0.875rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border: 2px solid #e5e7eb;
+}
+
+.toggle-switch:hover {
+  background: #d1d5db;
+  border-color: #d1d5db;
+}
+
+.toggle-switch.checked {
+  background: #22c55e;
+  border-color: #22c55e;
+}
+
+.toggle-switch.checked:hover {
+  background: #16a34a;
+  border-color: #16a34a;
+}
+
+.toggle-switch.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.toggle-switch-slider {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.toggle-switch-thumb {
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  background: white;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.toggle-switch.checked .toggle-switch-thumb {
+  transform: translateX(1.75rem);
+}
+
+/* 地図のスタイル */
+.map-container {
+  background: white;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  border: 1px solid #e5e7eb;
+}
+
+.map-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 600px;
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  border: 1px solid #e5e7eb;
+}
+
+.map-loading .loading-spinner {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.map-loading p {
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.map-no-results {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 600px;
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  border: 1px solid #e5e7eb;
+  text-align: center;
+  padding: 2rem;
+}
+
+.map-no-results h3 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 0.5rem;
+}
+
+.map-stats {
+  background: #f9fafb;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid #e5e7eb;
+  text-align: center;
+  font-size: 0.875rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+/* 地図表示時の検索結果ヘッダー調整 */
+.view-toggle-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.results-header-with-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  background: white;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border: 1px solid #e5e7eb;
+}
+
+.results-title-container {
+  flex: 1;
+}
+
+.toggle-container {
+  flex-shrink: 0;
+}
+
+/* Leafletマーカーのカスタマイズ */
+.leaflet-popup-content-wrapper {
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.leaflet-popup-content {
+  margin: 0.75rem;
+  line-height: 1.4;
+}
+
+.leaflet-popup-tip {
+  background: white;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .toggle-switch-wrapper {
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+  }
+  
+  .toggle-switch-label {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+  }
+  
+  .toggle-switch {
+    width: 3rem;
+    height: 1.5rem;
+  }
+  
+  .toggle-switch-thumb {
+    width: 1rem;
+    height: 1rem;
+  }
+  
+  .toggle-switch.checked .toggle-switch-thumb {
+    transform: translateX(1.5rem);
+  }
+  
+  .results-header-with-toggle {
+    flex-direction: column;
+    text-align: center;
+  }
+  
+  .map-container {
+    margin: 0 -1rem;
+    border-radius: 0;
+    width: 100%;
+    height: 600px;
+  }
+}
+
+@media (max-width: 480px) {
+  .toggle-switch-container {
+    margin: 0 -1rem 1.5rem;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+  
+  .map-stats {
+    font-size: 0.75rem;
+    padding: 0.5rem;
+  }
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
【プロンプト】
地図機能を追加する。検索画面上部にトグルスイッチを配置し、既存の検索結果を表示するかマップを表示するかを切り替える。マップ状態で検索すると、OpenStreetMapを利用しながら、検索結果の各事業所のfacility.latitudeとfacility.longitudeから事業所の位置をマップ上に示す。事業所にカーソルをもっていくと詳細が表示される。

【バグ】
「地図を読み込み中...」の状態から変化しない。

【仕様】
検索結果上部にリスト表示/地図表示の切替トグルスイッチを配置
アイコン付きの分かりやすいインターフェース
OpenStreetMap地図表示

Leafletライブラリを使用した地図機能
事業所の位置をマーカーで表示
マーカーとポップアップ

カスタムデザインのマーカーアイコン（緑色の建物アイコン）
マーカーホバー/クリックで事業所詳細をポップアップ表示
ポップアップには事業所名、住所、サービス、連絡先などを表示
自動地図調整

検索結果に応じて地図の表示範囲を自動調整
複数の事業所がある場合は全体が見えるように調整
1件のみの場合は適切なズームレベルで表示
