### PR TITLE
modify index with useBookmarks

### DIFF
--- a/pages/facilities/[id].tsx
+++ b/pages/facilities/[id].tsx
@@ -227,7 +227,7 @@ const InfoCard: React.FC<{
 // 事業所詳細ページコンポーネント（レスポンシブ対応）
 const FacilityDetailPage: React.FC = () => {
   const router = useRouter();
-  const { id, ...searchParams } = router.query;
+  const { id, bookmark, ...searchParams } = router.query;
   const { user, signOut } = useAuthContext();
   const { isBookmarked, toggleBookmark } = useBookmarks();
   const { isMobile, isDesktop } = useDevice();
@@ -241,6 +241,12 @@ const FacilityDetailPage: React.FC = () => {
 
   // 検索に戻るためのURL構築（地図表示状態も考慮）
   const getBackToSearchUrl = () => {
+    // ブックマークモードから遷移した場合
+    if (bookmark === '1') {
+      return '/?from_bookmark=1'; // ブックマークから戻ってきたことを示すパラメータを追加
+    }
+
+    // 通常の検索から遷移した場合は既存のロジック
     const params = new URLSearchParams();
     
     const getString = (value: string | string[] | undefined): string => {
@@ -286,6 +292,12 @@ const FacilityDetailPage: React.FC = () => {
 
   // パンくずリストの表示テキストを取得
   const getBreadcrumbText = () => {
+    // ブックマークモードから遷移した場合
+    if (bookmark === '1') {
+      return 'ブックマーク';
+    }
+
+    // 通常の検索から遷移した場合は既存のロジック
     const hasParams = Object.keys(searchParams).some(key => key !== 'view' && searchParams[key]);
     const isMapView = searchParams.view === 'map' || !searchParams.view;
     


### PR DESCRIPTION
【プロンプト】
ブックマークタブで検索したときに出てくる事業所一覧から事業所詳細ページに飛んだ後、「検索結果」をクリックしてブックマークタブに戻るようにしたい。しかし、現状は「地図表示」となってしまっている。

【仕様】
Supabaseの直接インポート: getUserBookmarks 関数を直接インポートして使用
重複実行防止: isRestoringBookmarks フラグで重複実行を防ぐ
ブックマーク復元処理: URLパラメータ from_bookmark=1 を検知してブックマークタブを自動復元
エラーハンドリング: 各段階でのエラー処理とログ出力
Footer修正: propsなしで呼び出すよう修正

この修正により、ブックマークタブ → 事業所詳細 → ブックマークタブの流れが正しく動作し、ブックマークした事業所一覧も正しく表示されるはずです。