### PR TITLE
add DM tab to my page

### DIFF
--- a/components/dm/ConversationList.tsx
+++ b/components/dm/ConversationList.tsx
@@ -1,0 +1,220 @@
+// components/dm/ConversationList.tsx
+import React from 'react';
+import { MessageCircle, User } from 'lucide-react';
+import { useAuthContext } from '@/components/providers/AuthProvider';
+import { type Conversation } from '@/lib/hooks/useMessages';
+
+interface ConversationListProps {
+  conversations: Conversation[];
+  onSelectConversation: (conversation: Conversation) => void;
+  selectedConversationId?: string;
+  loading?: boolean;
+}
+
+const ConversationList: React.FC<ConversationListProps> = ({
+  conversations,
+  onSelectConversation,
+  selectedConversationId,
+  loading = false
+}) => {
+  const { user } = useAuthContext();
+
+  const getOtherPartyInfo = (conversation: Conversation) => {
+    if (!user) return { name: '', subtitle: '' };
+    
+    // 利用者用のDMシステムなので、常に事業所名を表示
+    return {
+      name: conversation.facility?.name || '事業所',
+      subtitle: ''
+    };
+  };
+
+  const formatLastMessageTime = (timestamp: string) => {
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays === 0) {
+      return date.toLocaleTimeString('ja-JP', { 
+        hour: '2-digit', 
+        minute: '2-digit' 
+      });
+    } else if (diffDays === 1) {
+      return '昨日';
+    } else if (diffDays < 7) {
+      return `${diffDays}日前`;
+    } else {
+      return date.toLocaleDateString('ja-JP', { 
+        month: 'short', 
+        day: 'numeric' 
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{
+        padding: '2rem',
+        textAlign: 'center',
+        color: '#6b7280'
+      }}>
+        会話を読み込み中...
+      </div>
+    );
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <div style={{
+        padding: '3rem 2rem',
+        textAlign: 'center',
+        color: '#6b7280'
+      }}>
+        <MessageCircle size={48} style={{ margin: '0 auto 1rem', color: '#d1d5db' }} />
+        <h3 style={{ margin: '0 0 0.5rem 0', fontSize: '1.125rem', color: '#374151' }}>
+          メッセージがありません
+        </h3>
+        <p style={{ margin: 0, fontSize: '0.875rem' }}>
+          事業所の詳細ページからメッセージを送信してみましょう
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '1rem 0' }}>
+      <h2 style={{
+        margin: '0 0 1rem 1rem',
+        fontSize: '1.25rem',
+        fontWeight: 600,
+        color: '#111827'
+      }}>
+        メッセージ
+      </h2>
+      
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        {conversations.map((conversation) => {
+          const otherParty = getOtherPartyInfo(conversation);
+          const isSelected = conversation.id === selectedConversationId;
+          const isUnread = conversation.last_message && 
+                          conversation.last_message.sender_id !== user?.id;
+
+          return (
+            <button
+              key={conversation.id}
+              onClick={() => onSelectConversation(conversation)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '1rem',
+                padding: '1rem',
+                border: 'none',
+                background: isSelected ? '#f0fdf4' : 'transparent',
+                borderLeft: isSelected ? '4px solid #22c55e' : '4px solid transparent',
+                cursor: 'pointer',
+                textAlign: 'left',
+                transition: 'all 0.2s'
+              }}
+              onMouseEnter={(e) => {
+                if (!isSelected) {
+                  e.currentTarget.style.background = '#f9fafb';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!isSelected) {
+                  e.currentTarget.style.background = 'transparent';
+                }
+              }}
+            >
+              {/* アバター */}
+              <div style={{
+                width: '48px',
+                height: '48px',
+                borderRadius: '50%',
+                background: isSelected ? '#22c55e' : '#e5e7eb',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: isSelected ? 'white' : '#6b7280',
+                flexShrink: 0
+              }}>
+                <User size={24} />
+              </div>
+
+              {/* 内容 */}
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: '0.25rem'
+                }}>
+                  <h3 style={{
+                    margin: 0,
+                    fontSize: '1rem',
+                    fontWeight: isUnread ? 600 : 500,
+                    color: '#111827',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap'
+                  }}>
+                    {otherParty.name}
+                  </h3>
+                  <span style={{
+                    fontSize: '0.75rem',
+                    color: '#6b7280',
+                    flexShrink: 0
+                  }}>
+                    {formatLastMessageTime(conversation.last_message_at)}
+                  </span>
+                </div>
+
+                {otherParty.subtitle && (
+                  <p style={{
+                    margin: '0 0 0.25rem 0',
+                    fontSize: '0.75rem',
+                    color: '#6b7280',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap'
+                  }}>
+                    {otherParty.subtitle}
+                  </p>
+                )}
+
+                {conversation.last_message && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                    <p style={{
+                      margin: 0,
+                      fontSize: '0.875rem',
+                      color: '#6b7280',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                      flex: 1
+                    }}>
+                      {conversation.last_message.sender_id === user?.id ? '自分: ' : ''}
+                      {conversation.last_message.content}
+                    </p>
+                    {isUnread && (
+                      <div style={{
+                        width: '8px',
+                        height: '8px',
+                        borderRadius: '50%',
+                        background: '#22c55e',
+                        flexShrink: 0
+                      }} />
+                    )}
+                  </div>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ConversationList;

--- a/components/dm/MessageThread.tsx
+++ b/components/dm/MessageThread.tsx
@@ -1,0 +1,245 @@
+// components/dm/MessageThread.tsx
+import React, { useState, useEffect, useRef } from 'react';
+import { Send, ArrowLeft, User } from 'lucide-react';
+import { useAuthContext } from '@/components/providers/AuthProvider';
+import { useMessages, type Message, type Conversation } from '@/lib/hooks/useMessages';
+
+interface MessageThreadProps {
+  conversation: Conversation;
+  onClose: () => void;
+}
+
+const MessageThread: React.FC<MessageThreadProps> = ({ conversation, onClose }) => {
+  const { user } = useAuthContext();
+  const { messages, fetchMessages, sendMessage, loading } = useMessages();
+  const [newMessage, setNewMessage] = useState('');
+  const [sending, setSending] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // メッセージを取得
+  useEffect(() => {
+    if (conversation.id) {
+      fetchMessages(conversation.id);
+    }
+  }, [conversation.id, fetchMessages]);
+
+  // 新しいメッセージが来たら自動スクロール
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const handleSendMessage = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newMessage.trim() || sending || !user) return;
+
+    try {
+      setSending(true);
+      
+      await sendMessage(conversation.id, newMessage.trim());
+      setNewMessage('');
+    } catch (error) {
+      console.error('メッセージ送信エラー:', error);
+      alert('メッセージの送信に失敗しました');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const getOtherPartyName = () => {
+    if (!user) return '';
+    
+    // 利用者が見る場合は事業所名を表示
+    return conversation.facility?.name || '事業所';
+  };
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+      background: 'white',
+      borderRadius: '0.5rem',
+      border: '1px solid #e5e7eb'
+    }}>
+      {/* ヘッダー */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '1rem',
+        padding: '1rem',
+        borderBottom: '1px solid #e5e7eb',
+        background: '#f9fafb'
+      }}>
+        <button
+          onClick={onClose}
+          style={{
+            padding: '0.5rem',
+            border: 'none',
+            background: 'none',
+            cursor: 'pointer',
+            borderRadius: '0.25rem',
+            display: 'flex',
+            alignItems: 'center',
+            color: '#6b7280'
+          }}
+        >
+          <ArrowLeft size={20} />
+        </button>
+        
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <div style={{
+            width: '40px',
+            height: '40px',
+            borderRadius: '50%',
+            background: '#22c55e',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'white'
+          }}>
+            <User size={20} />
+          </div>
+          <div>
+            <h3 style={{ 
+              margin: 0, 
+              fontSize: '1rem', 
+              fontWeight: 600, 
+              color: '#111827' 
+            }}>
+              {getOtherPartyName()}
+            </h3>
+            <p style={{ 
+              margin: 0, 
+              fontSize: '0.875rem', 
+              color: '#6b7280' 
+            }}>
+              {conversation.facility?.name && `事業所: ${conversation.facility.name}`}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* メッセージ一覧 */}
+      <div style={{
+        flex: 1,
+        padding: '1rem',
+        overflowY: 'auto',
+        maxHeight: '400px'
+      }}>
+        {loading ? (
+          <div style={{ textAlign: 'center', color: '#6b7280' }}>
+            メッセージを読み込み中...
+          </div>
+        ) : messages.length === 0 ? (
+          <div style={{ 
+            textAlign: 'center', 
+            color: '#6b7280',
+            padding: '2rem' 
+          }}>
+            まだメッセージがありません。
+            <br />
+            最初のメッセージを送信してみましょう！
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            {messages.map((message) => {
+              const isMyMessage = message.sender_id === user?.id;
+              
+              return (
+                <div
+                  key={message.id}
+                  style={{
+                    display: 'flex',
+                    justifyContent: isMyMessage ? 'flex-end' : 'flex-start'
+                  }}
+                >
+                  <div style={{
+                    maxWidth: '70%',
+                    padding: '0.75rem 1rem',
+                    borderRadius: isMyMessage 
+                      ? '1rem 1rem 0.25rem 1rem' 
+                      : '1rem 1rem 1rem 0.25rem',
+                    background: isMyMessage ? '#22c55e' : '#f3f4f6',
+                    color: isMyMessage ? 'white' : '#111827'
+                  }}>
+                    <p style={{ 
+                      margin: 0, 
+                      fontSize: '0.875rem',
+                      lineHeight: '1.5'
+                    }}>
+                      {message.content}
+                    </p>
+                    <p style={{
+                      margin: '0.25rem 0 0 0',
+                      fontSize: '0.75rem',
+                      opacity: 0.7
+                    }}>
+                      {new Date(message.created_at).toLocaleString('ja-JP', {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit'
+                      })}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* メッセージ入力 */}
+      <form onSubmit={handleSendMessage} style={{
+        display: 'flex',
+        gap: '0.5rem',
+        padding: '1rem',
+        borderTop: '1px solid #e5e7eb',
+        background: '#f9fafb'
+      }}>
+        <input
+          type="text"
+          value={newMessage}
+          onChange={(e) => setNewMessage(e.target.value)}
+          placeholder="メッセージを入力..."
+          disabled={sending}
+          style={{
+            flex: 1,
+            padding: '0.75rem',
+            border: '1px solid #d1d5db',
+            borderRadius: '0.5rem',
+            outline: 'none',
+            fontSize: '0.875rem'
+          }}
+        />
+        <button
+          type="submit"
+          disabled={!newMessage.trim() || sending}
+          style={{
+            padding: '0.75rem 1rem',
+            background: !newMessage.trim() || sending ? '#d1d5db' : '#22c55e',
+            color: 'white',
+            border: 'none',
+            borderRadius: '0.5rem',
+            cursor: !newMessage.trim() || sending ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            fontSize: '0.875rem',
+            fontWeight: 500
+          }}
+        >
+          <Send size={16} />
+          {sending ? '送信中...' : '送信'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default MessageThread;

--- a/lib/hooks/useMessages.ts
+++ b/lib/hooks/useMessages.ts
@@ -1,0 +1,329 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../supabase/client';
+import { useAuthContext } from '@/components/providers/AuthProvider';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+export interface Message {
+  id: string;
+  conversation_id: string;
+  sender_id: string;
+  receiver_id: string;
+  content: string;
+  is_read: boolean;
+  created_at: string;
+  updated_at: string;
+  sender?: {
+    full_name: string;
+    user_type: 'user' | 'facility';
+  };
+}
+
+export interface Conversation {
+  id: string;
+  user_id: string;
+  facility_id: number;
+  last_message_at: string;
+  created_at: string;
+  updated_at: string;
+  user?: {
+    full_name: string;
+  };
+  facility?: {
+    name: string;
+  };
+  last_message?: {
+    content: string;
+    sender_id: string;
+  };
+}
+
+export function useMessages() {
+  const { user } = useAuthContext();
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [realtimeChannel, setRealtimeChannel] = useState<RealtimeChannel | null>(null);
+
+  // 会話一覧を取得
+  const fetchConversations = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      // 会話データを取得
+      const { data: conversationData, error: convError } = await supabase
+        .from('conversations')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('last_message_at', { ascending: false });
+
+      if (convError) throw convError;
+
+      if (!conversationData || conversationData.length === 0) {
+        setConversations([]);
+        return;
+      }
+
+      // 各会話に対して、ユーザー情報、事業所情報、最後のメッセージを取得
+      const conversationsWithDetails = await Promise.all(
+        conversationData.map(async (conv) => {
+          // ユーザー情報を取得
+          const { data: userData } = await supabase
+            .from('users')
+            .select('full_name')
+            .eq('id', conv.user_id)
+            .single();
+
+          // 事業所情報を取得
+          const { data: facilityData } = await supabase
+            .from('facilities')
+            .select('name')
+            .eq('id', conv.facility_id)
+            .single();
+
+          // 最後のメッセージを取得
+          const { data: lastMessage } = await supabase
+            .from('messages')
+            .select('content, sender_id')
+            .eq('conversation_id', conv.id)
+            .order('created_at', { ascending: false })
+            .limit(1)
+            .single();
+
+          return {
+            ...conv,
+            user: userData,
+            facility: facilityData,
+            last_message: lastMessage
+          };
+        })
+      );
+
+      setConversations(conversationsWithDetails);
+    } catch (err: any) {
+      setError(err.message);
+      console.error('会話一覧取得エラー:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  // 特定の会話のメッセージを取得
+  const fetchMessages = useCallback(async (conversationId: string) => {
+    if (!user) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      // メッセージ基本データを取得
+      const { data: messageData, error } = await supabase
+        .from('messages')
+        .select('*')
+        .eq('conversation_id', conversationId)
+        .order('created_at', { ascending: true });
+
+      if (error) throw error;
+
+      // 送信者情報を別途取得
+      const messagesWithSender = await Promise.all(
+        (messageData || []).map(async (message) => {
+          const { data: senderData } = await supabase
+            .from('users')
+            .select('full_name, user_type')
+            .eq('id', message.sender_id)
+            .single();
+
+          return {
+            ...message,
+            sender: senderData
+          };
+        })
+      );
+
+      setMessages(messagesWithSender);
+
+      // 自分宛の未読メッセージを既読にする
+      await supabase
+        .from('messages')
+        .update({ is_read: true })
+        .eq('conversation_id', conversationId)
+        .neq('sender_id', user.id)
+        .eq('is_read', false);
+
+    } catch (err: any) {
+      setError(err.message);
+      console.error('メッセージ取得エラー:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  // 会話を作成または取得（簡略化版）
+  const getOrCreateConversation = useCallback(async (
+    userId: string, 
+    facilityId: number
+  ) => {
+    try {
+      // 既存の会話を確認
+      const { data: existingConv, error: fetchError } = await supabase
+        .from('conversations')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('facility_id', facilityId)
+        .single();
+
+      if (existingConv) {
+        return existingConv.id;
+      }
+
+      // 新しい会話を作成
+      const { data: newConv, error: createError } = await supabase
+        .from('conversations')
+        .insert({
+          user_id: userId,
+          facility_id: facilityId
+        })
+        .select()
+        .single();
+
+      if (createError) throw createError;
+      return newConv.id;
+    } catch (err: any) {
+      console.error('会話作成エラー:', err);
+      throw err;
+    }
+  }, []);
+
+  // メッセージを送信（簡略化版）
+  const sendMessage = useCallback(async (
+    conversationId: string,
+    content: string
+  ) => {
+    if (!user) throw new Error('ログインが必要です');
+
+    try {
+      const { data, error } = await supabase
+        .from('messages')
+        .insert({
+          conversation_id: conversationId,
+          sender_id: user.id,
+          content: content
+        })
+        .select()
+        .single();
+
+      if (error) throw error;
+
+      // 会話の最終メッセージ時刻を更新
+      await supabase
+        .from('conversations')
+        .update({ 
+          last_message_at: new Date().toISOString(),
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', conversationId);
+
+      return data;
+    } catch (err: any) {
+      console.error('メッセージ送信エラー:', err);
+      throw err;
+    }
+  }, [user]);
+
+  // 未読メッセージ数を取得
+  const getUnreadCount = useCallback(async () => {
+    if (!user) return 0;
+
+    try {
+      // ユーザーの会話IDを取得
+      const { data: userConversations } = await supabase
+        .from('conversations')
+        .select('id')
+        .eq('user_id', user.id);
+
+      if (!userConversations || userConversations.length === 0) {
+        return 0;
+      }
+
+      const conversationIds = userConversations.map(c => c.id);
+
+      // 未読メッセージ数を取得
+      const { count, error } = await supabase
+        .from('messages')
+        .select('*', { count: 'exact', head: true })
+        .in('conversation_id', conversationIds)
+        .neq('sender_id', user.id)
+        .eq('is_read', false);
+
+      if (error) throw error;
+      return count || 0;
+    } catch (err: any) {
+      console.error('未読数取得エラー:', err);
+      return 0;
+    }
+  }, [user]);
+
+  // Realtimeセットアップ
+  useEffect(() => {
+    if (!user) return;
+
+    const channel = supabase
+      .channel('messages')
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'messages'
+        },
+        (payload) => {
+          console.log('新しいメッセージ:', payload.new);
+          fetchConversations();
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'conversations',
+          filter: `user_id=eq.${user.id}`
+        },
+        (payload) => {
+          console.log('新しい会話:', payload.new);
+          fetchConversations();
+        }
+      )
+      .subscribe();
+
+    setRealtimeChannel(channel);
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [user, fetchConversations]);
+
+  // 初期データ読み込み
+  useEffect(() => {
+    if (user) {
+      fetchConversations();
+    }
+  }, [user, fetchConversations]);
+
+  return {
+    conversations,
+    messages,
+    loading,
+    error,
+    fetchConversations,
+    fetchMessages,
+    getOrCreateConversation,
+    sendMessage,
+    getUnreadCount,
+    setMessages
+  };
+}

--- a/pages/business/mypage.tsx
+++ b/pages/business/mypage.tsx
@@ -6,11 +6,14 @@ import Head from 'next/head'
 import { 
   Building2, User, Mail, Phone, MapPin, Globe, FileText,
   Eye, EyeOff, Save, Edit3, Settings, Lock, Award,
-  AlertCircle, CheckCircle, Image, Star, ArrowLeft
+  AlertCircle, CheckCircle, Image, Star, ArrowLeft, MessageCircle
 } from 'lucide-react'
 import { useAuthContext } from '@/components/providers/AuthProvider'
+import { useMessages } from '@/lib/hooks/useMessages'
 import { supabase } from '@/lib/supabase/client'
 import Header from '../../components/layout/Header'
+import ConversationList from '@/components/dm/ConversationList'
+import MessageThread from '@/components/dm/MessageThread'
 
 const TOKYO_DISTRICTS = [
   // 23区
@@ -769,12 +772,17 @@ const ServiceManagement: React.FC<{
 const FacilityMyPage: React.FC = () => {
   const router = useRouter()
   const { user, signOut } = useAuthContext()
+  const { conversations, fetchConversations, loading: messagesLoading } = useMessages()
   
-  const [activeTab, setActiveTab] = useState<'profile' | 'facility' | 'services' | 'account'>('profile')
+  const [activeTab, setActiveTab] = useState<'profile' | 'facility' | 'services' | 'account' | 'messages'>('profile')
   const [isEditing, setIsEditing] = useState(false)
   const [loading, setLoading] = useState(false)
   const [initialLoading, setInitialLoading] = useState(true)
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  
+  // DM関連の状態
+  const [selectedConversation, setSelectedConversation] = useState<any>(null)
+  const [showMessageThread, setShowMessageThread] = useState(false)
   
   const [profileData, setProfileData] = useState({
     // 担当者情報 (usersテーブル)
@@ -1034,7 +1042,8 @@ const FacilityMyPage: React.FC = () => {
     { key: 'profile', label: '担当者情報', icon: User },
     { key: 'facility', label: '事業所情報', icon: Building2 },
     { key: 'services', label: 'サービス管理', icon: Award },
-    { key: 'account', label: 'アカウント設定', icon: Settings }
+    { key: 'account', label: 'アカウント設定', icon: Settings },
+    { key: 'messages', label: 'メッセージ', icon: MessageCircle }
   ]
 
   // ログインチェック
@@ -1751,6 +1760,31 @@ const FacilityMyPage: React.FC = () => {
                   </MyPageButton>
                 </Link>
               </div>
+            </div>
+          )}
+
+          {/* メッセージタブ */}
+          {activeTab === 'messages' && (
+            <div>
+              {showMessageThread && selectedConversation ? (
+                <MessageThread
+                  conversation={selectedConversation}
+                  onClose={() => {
+                    setShowMessageThread(false)
+                    setSelectedConversation(null)
+                  }}
+                />
+              ) : (
+                <ConversationList
+                  conversations={conversations}
+                  onSelectConversation={(conversation) => {
+                    setSelectedConversation(conversation)
+                    setShowMessageThread(true)
+                  }}
+                  selectedConversationId={selectedConversation?.id}
+                  loading={messagesLoading}
+                />
+              )}
             </div>
           )}
         </div>

--- a/pages/facilities/[id].tsx
+++ b/pages/facilities/[id].tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { useAuthContext } from '@/components/providers/AuthProvider';
 import { useBookmarks } from '@/lib/hooks/useBookmarks';
 import { useDevice } from '@/hooks/useDevice';
+import { supabase } from '@/lib/supabase/client';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 import { MapPin, Phone, Globe, MessageCircle, Heart, ArrowLeft, Clock, Users, Star, Building, Calendar, ExternalLink, Send, X, Paperclip, Smile } from 'lucide-react';
@@ -352,13 +353,19 @@ const FacilityDetailPage: React.FC = () => {
   };
 
   // DM機能の処理
-  const handleDMClick = () => {
-    if (!isLoggedIn) {
+  const handleDMClick = async () => {
+    if (!isLoggedIn || !facility) {
       alert('DM機能を使用するにはログインが必要です。');
       return;
     }
-    // 実際の実装時はここでDMページへの遷移やモーダル表示を行う
-    alert('DM機能は開発中です。現在はお電話またはメールでお問い合わせください。');
+
+    try {
+      // 利用者マイページのメッセージタブに遷移
+      router.push(`/mypage?tab=messages&facility=${facility.id}`);
+    } catch (error) {
+      console.error('DM機能エラー:', error);
+      alert('メッセージ機能でエラーが発生しました。');
+    }
   };
 
   // ローディング状態
@@ -874,10 +881,7 @@ const FacilityDetailPage: React.FC = () => {
         </div>
       </main>
 
-      <Footer 
-        isLoggedIn={isLoggedIn}
-        signOut={signOut}
-      />
+      <Footer />
     </div>
   );
 };

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -11,9 +11,12 @@ import {
 } from 'lucide-react'
 import { useAuthContext } from '@/components/providers/AuthProvider'
 import { useBookmarks } from '@/lib/hooks/useBookmarks'
+import { useMessages } from '@/lib/hooks/useMessages'
 import { supabase } from '@/lib/supabase/client'
 import { TokyoDistrict, DisabilityType } from '@/types/database'
-import Header from '../../components/layout/Header';
+import Header from '../../components/layout/Header'
+import ConversationList from '@/components/dm/ConversationList'
+import MessageThread from '@/components/dm/MessageThread'
 
 const TOKYO_DISTRICTS: TokyoDistrict[] = [
   // 23区
@@ -149,12 +152,17 @@ const UserMyPage: React.FC = () => {
   const router = useRouter()
   const { user, signOut } = useAuthContext()
   const { bookmarks, refreshBookmarks, toggleBookmark, isBookmarked } = useBookmarks()
+  const { conversations, fetchConversations, getOrCreateConversation, loading: messagesLoading } = useMessages()
   
-  const [activeTab, setActiveTab] = useState<'profile' | 'personal' | 'support' | 'account' | 'bookmarks'>('profile')
+  const [activeTab, setActiveTab] = useState<'profile' | 'personal' | 'support' | 'account' | 'bookmarks' | 'messages'>('profile')
   const [isEditing, setIsEditing] = useState(false)
   const [loading, setLoading] = useState(false)
   const [initialLoading, setInitialLoading] = useState(true)
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+  
+  // DM関連の状態
+  const [selectedConversation, setSelectedConversation] = useState<any>(null)
+  const [showMessageThread, setShowMessageThread] = useState(false)
   
   const [profileData, setProfileData] = useState({
     // 基本情報 (usersテーブル)
@@ -195,7 +203,7 @@ const UserMyPage: React.FC = () => {
 
   const [bookmarkedFacilities, setBookmarkedFacilities] = useState<any[]>([])
 
-  // 修正された初期データ読み込み処理
+  // 初期データ読み込み
   useEffect(() => {
     const loadUserData = async () => {
       if (!user) return
@@ -351,6 +359,38 @@ const UserMyPage: React.FC = () => {
 
     loadUserData()
   }, [user])
+
+  // DM起動処理（URLパラメータから）
+  useEffect(() => {
+    const { tab, facility } = router.query
+    
+    if (tab === 'messages' && facility && user) {
+      setActiveTab('messages')
+      setShowMessageThread(false) // 最初は一覧を表示
+      
+      // 事業所との会話を作成または取得
+      const handleFacilityMessage = async () => {
+        try {
+          const facilityId = Array.isArray(facility) ? facility[0] : facility
+          
+          // 会話を作成または取得
+          const conversationId = await getOrCreateConversation(
+            user.id, 
+            parseInt(facilityId)
+          )
+          
+          if (conversationId) {
+            // 会話一覧を更新
+            await fetchConversations()
+          }
+        } catch (error) {
+          console.error('会話作成エラー:', error)
+        }
+      }
+      
+      handleFacilityMessage()
+    }
+  }, [router.query, user, getOrCreateConversation, fetchConversations])
 
   // ブックマーク読み込み
   useEffect(() => {
@@ -734,7 +774,8 @@ const UserMyPage: React.FC = () => {
     { key: 'personal', label: '個人情報', icon: Heart },
     { key: 'support', label: 'サポート情報', icon: Shield },
     { key: 'account', label: 'アカウント設定', icon: Settings },
-    { key: 'bookmarks', label: 'ブックマーク', icon: Star }
+    { key: 'bookmarks', label: 'ブックマーク', icon: Star },
+    { key: 'messages', label: 'メッセージ', icon: MessageCircle }
   ]
 
   // ログインチェック
@@ -1503,6 +1544,31 @@ const UserMyPage: React.FC = () => {
                     </div>
                   ))}
                 </div>
+              )}
+            </div>
+          )}
+
+          {/* メッセージタブ */}
+          {activeTab === 'messages' && (
+            <div>
+              {showMessageThread && selectedConversation ? (
+                <MessageThread
+                  conversation={selectedConversation}
+                  onClose={() => {
+                    setShowMessageThread(false)
+                    setSelectedConversation(null)
+                  }}
+                />
+              ) : (
+                <ConversationList
+                  conversations={conversations}
+                  onSelectConversation={(conversation) => {
+                    setSelectedConversation(conversation)
+                    setShowMessageThread(true)
+                  }}
+                  selectedConversationId={selectedConversation?.id}
+                  loading={messagesLoading}
+                />
               )}
             </div>
           )}


### PR DESCRIPTION
【プロンプト】
[id].tsxのhandleDMClick関数に、利用者マイページ(pages\mypage\index.tsx)に飛んでDM画面を開き、メッセージを送れるようにする処理を追加したい。そして、事業所マイページ(pages\business\mypage.tsx)から確認し、返信できるようにしたい。会話ログを見れるようにして。ただし、Supabase Realtimeを利用せよ。その際に、必要なSupabaseの設定手順も教えて。

【仕様】
SUPABASE_DM_SETUP.mdにセットアップ方法を記述